### PR TITLE
Use serverHooks instead of Webhooks.Routes

### DIFF
--- a/scripts/register-webhooks.js
+++ b/scripts/register-webhooks.js
@@ -82,7 +82,7 @@ function getServerFunctions() {
 // Call the Hooks API and register/update triggers
 function registerTriggers(triggerType) {
   var promise = Parse.Promise.as();
-  Webhooks.Routes[triggerType].forEach(function(item) {
+  serverHooks[triggerType].forEach(function(item) {
     var url = baseURL + 'webhooks/' + triggerType + '_' + item;
     var data = getAuthenticatedRequestData();
     data['className'] = item;
@@ -131,7 +131,7 @@ function registerAfterDeletes() {
 // Call the Hooks API and register cloud functions
 function registerFunctions() {
   var promise = Parse.Promise.as();
-  Webhooks.Routes['function'].forEach(function(item) {
+  serverHooks['function'].forEach(function(item) {
     var url = baseURL + 'webhooks/function_' + item;
     var data = getAuthenticatedRequestData();
     data['functionName'] = item;


### PR DESCRIPTION
When running `npm run register` I noticed that not all webhooks on Parse were updated.
I experienced the same issue as stated here: https://github.com/ParsePlatform/CloudCode-Express/issues/5 

When running `register-webhooks.js` I realised that only 10 requests consistently got sent to parse - even though I have over 20 webhooks. The script also recieved all hooks [here](https://github.com/ParsePlatform/CloudCode-Express/blob/master/scripts/register-webhooks.js#L51) but all my functions were not updated in `registerFunctions`.

I still haven't figured out why all hooks weren't included in `Webhooks.Routes`. Either way by using `serverHooks` instead all of my hooks are included in `registerFunctions`.