### PR TITLE
Return the promise when waiting for webhook to register

### DIFF
--- a/scripts/register-webhooks.js
+++ b/scripts/register-webhooks.js
@@ -143,7 +143,7 @@ function registerFunctions() {
     }
     promise = promise.then(
         function() {
-          Parse._ajax('POST', path, JSON.stringify(data)).then(
+          return Parse._ajax('POST', path, JSON.stringify(data)).then(
               function (res) {
                 console.log('Registered function for: ' + item);
                 return Parse.Promise.as();


### PR DESCRIPTION
Registration *very* frequently fails when you're trying to register several webhooks. Presumably the Parse Hooks API isn't particularly fond of the very fast repeated requests. This makes each function registration wait for the previous to finish before it runs.